### PR TITLE
fix change in how post requests are handled in Standard Notes API calls

### DIFF
--- a/standardnotes_fs/api.py
+++ b/standardnotes_fs/api.py
@@ -24,7 +24,7 @@ class RESTAPI:
 
         logging.debug('POST json: ' + json.dumps(data, indent=4))
 
-        res = requests.post(url, json=data, headers=self.headers)
+        res = requests.post(url, data=data, headers=self.headers)
 
         # res.json() will fail if the response is empty/invalid JSON
         try:


### PR DESCRIPTION
snfs stopped working for me on May 26, 2021 after Standard Notes switched its server infrastructure. I think I've traced the change to how post requests are encoded. 